### PR TITLE
Proscenium cleanups. 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.23.1")
 
 //    testImplementation("androidx.compose.ui:ui-test-manifest:1.0.1")
+    implementation(kotlin("stdlib-jdk8"))
 
 }
 
@@ -81,4 +82,12 @@ compose.desktop {
             packageVersion = "1.0.0"
         }
     }
+}
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions {
+    jvmTarget = "1.8"
+}
+val compileTestKotlin: KotlinCompile by tasks
+compileTestKotlin.kotlinOptions {
+    jvmTarget = "1.8"
 }

--- a/src/main/kotlin/display/ComposeDrawingTools.kt
+++ b/src/main/kotlin/display/ComposeDrawingTools.kt
@@ -1,0 +1,23 @@
+package display
+
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import coordinates.PagePoint
+
+fun composeDraw(drawScope: DrawScope, orders: List<DrawingOrder>) {
+  orders.map {
+    when (it.operation) {
+      DrawingOrderOperation.CIRCLE -> drawScope.drawCircle(
+        color = it.color.compose,
+        center = PagePoint.drawingOffset(it.data[0], it.data[1]),
+        radius = it.data[2],
+        style = Stroke(width = 2f)
+      )
+      DrawingOrderOperation.LINE -> drawScope.drawLine(
+        color = it.color.compose,
+        start = PagePoint.drawingOffset(it.data[0], it.data[1]),
+        end = PagePoint.drawingOffset(it.data[2], it.data[3]),
+      )
+    }
+  }
+}

--- a/src/main/kotlin/display/DrawEntitiesCompose.kt
+++ b/src/main/kotlin/display/DrawEntitiesCompose.kt
@@ -1,19 +1,14 @@
 package display
 
 import Grid
+import PipeManager
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import coordinates.PagePoint
 import coordinates.Point
 import coordinates.VenuePoint
-import entities.Pipe
-import entities.PipeBase
-import entities.Proscenium
-import entities.Setpiece
-import entities.SetPlatform
-import entities.Shape
-import entities.Wall
+import entities.*
 
 fun drawContent(drawScope: DrawScope) {
   Grid.instance.draw(drawScope)
@@ -49,27 +44,8 @@ fun drawContent(drawScope: DrawScope) {
 }
 
 fun Proscenium.draw(drawScope: DrawScope) {
-//  println(toString())
-  drawScope.drawLine(Color.Cyan,
-    PagePoint.drawingOffset(origin.x - 17, origin.y - 17),
-    PagePoint.drawingOffset(origin.x + 17, origin.y + 17))
-  drawScope.drawLine(Color.Cyan,
-    PagePoint.drawingOffset(origin.x + 17, origin.y - 17),
-    PagePoint.drawingOffset(origin.x - 17, origin.y + 17))
-  drawScope.drawCircle(Color.Cyan, 17f, PagePoint.drawingOffset(origin.x, origin.y), style = Stroke(width = 2f))
-  val startX = origin.x - width / 2
-  val startY = origin.y
-  val endX = origin.x + width / 2
-  val endY = origin.y + depth
-  // SR end of proscenium arch
-  drawScope.drawLine(Color.Black, PagePoint.drawingOffset(startX, startY), PagePoint.drawingOffset(startX, endY))
-  // SL end of proscenium arch
-  drawScope.drawLine(Color.Black, PagePoint.drawingOffset(endX, startY), PagePoint.drawingOffset(endX, endY))
-
-  // US side of proscenium arch
-  drawScope.drawLine(Color.Gray, PagePoint.drawingOffset(startX, startY), PagePoint.drawingOffset(endX, startY))
-  // DS side of proscenium arch
-  drawScope.drawLine(Color.LightGray, PagePoint.drawingOffset(startX, endY), PagePoint.drawingOffset(endX, endY))
+  val drawingOrders = drawPlan()
+  composeDraw(drawScope, drawingOrders)
 }
 
 fun Wall.draw(drawScope: DrawScope) {
@@ -87,7 +63,7 @@ fun PipeBase.draw(drawScope: DrawScope) {
 
 fun Pipe.draw(drawScope: DrawScope, highlight: Boolean) {
   when (vertical) {
-    true-> drawVertical(drawScope)
+    true -> drawVertical(drawScope)
     else -> drawHorizontal(drawScope, highlight)
   }
 }
@@ -149,16 +125,3 @@ fun Shape.draw(drawScope: DrawScope, placement: VenuePoint) {
 //    platform.draw(origin)
 //  }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/main/kotlin/display/DrawEntitiesSvg.kt
+++ b/src/main/kotlin/display/DrawEntitiesSvg.kt
@@ -3,17 +3,7 @@ package display
 import SvgDocument
 import coordinates.Point
 import coordinates.VenuePoint
-import entities.Floor
-import entities.Luminaire
-import entities.LuminaireDefinition
-import entities.Pipe
-import entities.PipeBase
-import entities.Proscenium
-import entities.SetPlatform
-import entities.Setpiece
-import entities.Shape
-import entities.Venue
-import entities.Wall
+import entities.*
 
 fun drawSvgPipeDrawing(svgDocument: SvgDocument, pipe: Pipe) {
   for (instance in LuminaireDefinition.instances) {
@@ -56,7 +46,7 @@ fun drawSvgSectionContent(svgDocument: SvgDocument) {
 
   Venue.instances.first().drawSvgSection(svgDocument)
   Floor.instances.map { it.drawSvgSection(svgDocument) }
-//  Proscenium.drawSvgSection()
+  Proscenium.instances.first().drawSvgSection(svgDocument)
 //  Wall.instances.map { it.drawSvgSection(svgDocument) }
 //  Floor.instances.map { it.drawSvgSection(svgDocument) }
 //
@@ -89,29 +79,13 @@ fun Venue.drawSvgSection(svgDocument: SvgDocument) {
 }
 
 fun Proscenium.drawSvgPlan(svgDocument: SvgDocument) {
-  val (document, svgNamespace, generator, parentElement) = svgDocument
+  val drawingOrder = drawPlan()
+  svgDraw(svgDocument, drawingOrder)
+}
 
-  drawLine(document, svgNamespace, parentElement, origin.x - 17f, origin.y - 17f, origin.x + 17f, origin.y + 17f)
-    .addAttribute("stroke", "cyan")
-  drawLine(document, svgNamespace, parentElement, origin.x + 17f, origin.y - 17f, origin.x - 17f, origin.y + 17f)
-    .addAttribute("stroke", "cyan")
-  drawCircle(svgDocument, origin.x, origin.y, 17f).element
-    .addAttribute("stroke", "cyan")
-
-  val startX = origin.x - width / 2
-  val startY = origin.y
-  val endX = origin.x + width / 2
-  val endY = origin.y + depth
-  // SR end of proscenium arch
-  drawLine(document, svgNamespace, parentElement, startX, startY, startX, endY)
-  // SL end of proscenium arch
-  drawLine(document, svgNamespace, parentElement, endX, startY, endX, endY)
-  // US side of proscenium arch
-  drawLine(document, svgNamespace, parentElement, startX, startY, endX, startY)
-    .addAttribute("stroke-opacity", "0.3")
-  // DS side of proscenium arch
-  drawLine(document, svgNamespace, parentElement, startX, endY, endX, endY)
-    .addAttribute("stroke-opacity", "0.1")
+fun Proscenium.drawSvgSection(svgDocument: SvgDocument) {
+  val drawingOrder = drawSection()
+  svgDraw(svgDocument, drawingOrder)
 }
 
 fun Wall.drawSvgPlan(svgDocument: SvgDocument): SvgBoundary {

--- a/src/main/kotlin/display/DrawingOrder.kt
+++ b/src/main/kotlin/display/DrawingOrder.kt
@@ -1,0 +1,9 @@
+package display
+
+import androidx.compose.ui.graphics.Color
+
+data class DrawingOrder(
+  val operation: DrawingOrderOperation,
+  val data: List<Float>,
+  val color: IndependentColor = IndependentColor(Color.Black, "black"),
+)

--- a/src/main/kotlin/display/DrawingOrderOperation.kt
+++ b/src/main/kotlin/display/DrawingOrderOperation.kt
@@ -1,0 +1,6 @@
+package display
+
+enum class DrawingOrderOperation {
+  CIRCLE,  // Circle data is: x, y, r
+  LINE,  // Line data is: x1, y1, x2, y2
+}

--- a/src/main/kotlin/display/EntitiesDraw.kt
+++ b/src/main/kotlin/display/EntitiesDraw.kt
@@ -1,0 +1,100 @@
+package display
+
+import androidx.compose.ui.graphics.Color
+import display.DrawingOrder
+import entities.Proscenium
+import entities.Venue
+
+fun Proscenium.drawPlan(): List<DrawingOrder> {
+
+  val startX = origin.x - width / 2
+  val startY = origin.y
+  val endX = origin.x + width / 2
+  val endY = origin.y + depth
+  val originSize = 7f
+
+  val drawingOrders: MutableList<DrawingOrder> = mutableListOf()
+
+  val cyan = IndependentColor(Color.Cyan, "cyan")
+  drawingOrders.add(DrawingOrder(
+    DrawingOrderOperation.LINE,
+    listOf(origin.x - originSize, endY - originSize, origin.x + originSize, endY + originSize),
+    cyan
+  ))
+  drawingOrders.add(DrawingOrder(
+    DrawingOrderOperation.LINE,
+    listOf(origin.x + originSize, endY - originSize, origin.x - originSize, endY + originSize),
+    cyan
+  ))
+//  drawingOrders.add(DrawingOrder(
+//    DrawingOrderOperation.CIRCLE,
+//    listOf(origin.x, endY, originSize),
+//    cyan
+//  ))
+  // SR end of proscenium arch
+  drawingOrders.add(DrawingOrder(
+    DrawingOrderOperation.LINE,
+    listOf(startX, startY, startX, endY),
+  ))
+  // SL end of proscenium arch
+  drawingOrders.add(DrawingOrder(
+    DrawingOrderOperation.LINE,
+    listOf(endX, startY, endX, endY),
+  ))
+  // US side of proscenium arch
+  drawingOrders.add(DrawingOrder(
+    DrawingOrderOperation.LINE,
+    listOf(startX, startY, endX, startY),
+    IndependentColor(Color.Gray, "grey")
+  ))
+  // DS side of proscenium arch
+  drawingOrders.add(DrawingOrder(
+    DrawingOrderOperation.LINE,
+    listOf(startX, endY, endX, endY),
+    IndependentColor(Color.LightGray, "lightgrey")
+  ))
+
+  return drawingOrders.toList()
+}
+
+fun Proscenium.drawSection(): List<DrawingOrder> {
+  val venue = Venue.instances.first()
+  val floorHeight = venue.height - origin.z
+  val originY = venue.depth - origin.y
+  val originSize = 7f
+
+  val drawingOrders: MutableList<DrawingOrder> = mutableListOf()
+
+  val cyan = IndependentColor(Color.Cyan, "cyan")
+  drawingOrders.add(DrawingOrder(
+    DrawingOrderOperation.LINE,
+    listOf(originY - originSize, floorHeight - originSize, originY + originSize, floorHeight + originSize),
+    cyan
+  ))
+  drawingOrders.add(DrawingOrder(
+    DrawingOrderOperation.LINE,
+    listOf(originY + originSize, floorHeight - originSize, originY - originSize, floorHeight + originSize),
+    cyan
+  ))
+//  drawingOrders.add(DrawingOrder(
+//    DrawingOrderOperation.CIRCLE,
+//    listOf(originY, floorHeight, originSize),
+//    cyan
+//  ))
+  drawingOrders.add(DrawingOrder(
+    DrawingOrderOperation.LINE,
+    listOf(originY, floorHeight, originY, floorHeight - height),
+    IndependentColor(Color.Green, "green")
+  ))
+  drawingOrders.add(DrawingOrder(
+    DrawingOrderOperation.LINE,
+    listOf(originY + depth, floorHeight, originY + depth, floorHeight - height),
+  ))
+  drawingOrders.add(DrawingOrder(
+    DrawingOrderOperation.LINE,
+    listOf(originY, floorHeight - height, originY + depth, floorHeight - height),
+    IndependentColor(Color.Gray, "grey")
+  ))
+
+  return drawingOrders.toList()
+}

--- a/src/main/kotlin/display/IndependentColor.kt
+++ b/src/main/kotlin/display/IndependentColor.kt
@@ -1,0 +1,8 @@
+package display
+
+import androidx.compose.ui.graphics.Color
+
+data class IndependentColor(
+  val compose: Color,
+  val svg: String,
+)

--- a/src/main/kotlin/display/SvgDrawingTools.kt
+++ b/src/main/kotlin/display/SvgDrawingTools.kt
@@ -76,10 +76,34 @@ fun drawLine(
   svgElement.setAttribute("stroke-width", "2")
 
   return SvgBoundary(
-    min(start.x,end.x),
-    min(start.y,end.y),
-    max(start.x,end.x),
-    max(start.y,end.y),
+    min(start.x, end.x),
+    min(start.y, end.y),
+    max(start.x, end.x),
+    max(start.y, end.y),
+  )
+}
+
+fun drawLineWithResults(
+  svgDocument: SvgDocument,
+  start: VenuePoint,
+  end: VenuePoint,
+): DrawingResults {
+  val svgElement = makeElementInDocument(svgDocument, "line")
+  svgElement.setAttribute("x1", start.x.toString())
+  svgElement.setAttribute("y1", start.y.toString())
+  svgElement.setAttribute("x2", end.x.toString())
+  svgElement.setAttribute("y2", end.y.toString())
+  svgElement.setAttribute("stroke", "black")
+  svgElement.setAttribute("stroke-width", "2")
+
+  return DrawingResults(
+    svgElement,
+    SvgBoundary(
+      min(start.x, end.x),
+      min(start.y, end.y),
+      max(start.x, end.x),
+      max(start.y, end.y),
+    )
   )
 }
 
@@ -90,7 +114,7 @@ fun drawRectangle(
   width: Float,
   height: Float,
   fillColor: String = "white",
-  opacity: String = "1"
+  opacity: String = "1",
 ): DrawingResults {
   val rect = makeElementInDocument(svgDocument, "rect")
   rect.setAttribute("x", x.toString())
@@ -128,3 +152,29 @@ data class DrawingResults(
   val element: Element,
   val boundary: SvgBoundary,
 )
+
+fun svgDraw(svgDocument: SvgDocument, orders: List<DrawingOrder>) {
+  orders.map {
+    when (it.operation) {
+      DrawingOrderOperation.CIRCLE -> {
+        val result = drawCircle(
+          svgDocument = svgDocument,
+          x = it.data[0],
+          y = it.data[1],
+          r = it.data[2],
+//        color = it.color.compose,
+        )
+        result.element.addAttribute("stroke", it.color.svg)
+      }
+      DrawingOrderOperation.LINE -> {
+        val result = drawLineWithResults(
+          svgDocument = svgDocument,
+//        color = it.color.compose,
+          start = VenuePoint(it.data[0], it.data[1], 0f),
+          end = VenuePoint(it.data[2], it.data[3], 0f),
+        )
+        result.element.addAttribute("stroke", it.color.svg)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/entities/Proscenium.kt
+++ b/src/main/kotlin/entities/Proscenium.kt
@@ -14,9 +14,6 @@ class Proscenium(elementPassthrough: Element, parentEntity: XmlElemental?) : Xml
   val depth = getPositiveFloatAttribute("depth")
   val origin = VenuePoint(x, y, z)
 
-  init {
-  }
-
   override fun toString(): String {
     return "Proscenium at ($x, $y, $z) - width: $width, depth: $depth, height: $height."
   }

--- a/src/test/kotlin/tests/DrawEntitiesSvgTest.kt
+++ b/src/test/kotlin/tests/DrawEntitiesSvgTest.kt
@@ -9,7 +9,6 @@ import entities.LuminaireDefinition
 import entities.Pipe
 import entities.PipeBase
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
 import startSvg
 import tests.entities.FloorTest
 import tests.entities.LuminaireDefinitionTest
@@ -18,6 +17,7 @@ import tests.entities.PipeBaseTest
 import tests.entities.PipeTest
 import javax.imageio.metadata.IIOMetadataNode
 import kotlin.test.fail
+import kotlin.test.Test
 
 class DrawEntitiesSvgTest {
 


### PR DESCRIPTION
Fixed inverted drawing in plan view.

Implemented display of Proscenium in section view.

Fixing the Compose and SVG drawings separately annoyed me enough that I went ahead and implemented another layer in the drawing process. Now one set of `DrawingOrder`s is produced for each entity for each view. That list of `DrawingOrder`s is turned into Compose or SVG as needed, separating what to draw from how to draw it. This layer is currently only used for Proscenium -- I'll migrate away from the old paradigm over time.