### PR TITLE
Drowing more things in section and plan views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ hs_err_pid*
 **/.gradle/
 
 build/
+out/
 .DS_Store

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -82,7 +82,8 @@ fun App() {
         x, y, text,
       )
       if (pipeDisplay) {
-        PipeSideBar.pipeLister(PipeManager.list, PipeManager::makeCurrent)
+        PipeSideBar.pipeLister(PipeManager.list)
+//        PipeSideBar.pipeLister(PipeManager.list, PipeManager::makeCurrent)
       }
 
     }

--- a/src/main/kotlin/PipeManager.kt
+++ b/src/main/kotlin/PipeManager.kt
@@ -6,6 +6,7 @@ class PipeManager(
 ) {
 
   companion object {
+    var current = 0
     var list: List<PipeManager> = listOf()
     var currentLuminaires: List<Hangable> = listOf()
 
@@ -17,9 +18,10 @@ class PipeManager(
       list = mutableList.toList()
     }
 
-    fun makeCurrent(entry: PipeManager): Unit {
+    fun makeCurrent(entry: PipeManager) {
       println("Making ${entry.pipe.id} be current")
       val index = list.indexOf(entry)
+      current = index
       buildList(index)
       currentLuminaires = entry.pipe.dependents.map { it.hangable }.toList()
     }

--- a/src/main/kotlin/display/ComposeDrawingTools.kt
+++ b/src/main/kotlin/display/ComposeDrawingTools.kt
@@ -1,32 +1,93 @@
 package display
 
+import PipeManager
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import coordinates.PagePoint
 import display.DrawingOrderOperation.CIRCLE
 import display.DrawingOrderOperation.LINE
 import display.DrawingOrderOperation.RECTANGLE
+import display.DrawingOrderOperation.FILLED_RECTANGLE
+import display.DrawingOrderOperation.USE
+import entities.LuminaireDefinition
+import entities.Pipe
 
 fun composeDraw(drawScope: DrawScope, orders: List<DrawingOrder>) {
   orders.map {
+    val color = highlightIfCurrentPipe(it)
+
     when (it.operation) {
-      CIRCLE -> drawScope.drawCircle(
-        color = it.color.compose,
-        center = PagePoint.drawingOffset(it.data[0], it.data[1]),
-        radius = it.data[2],
-        style = Stroke(width = 2f)
-      )
-      LINE -> drawScope.drawLine(
-        color = it.color.compose,
-        start = PagePoint.drawingOffset(it.data[0], it.data[1]),
-        end = PagePoint.drawingOffset(it.data[2], it.data[3]),
-      )
-      RECTANGLE -> drawScope.drawRect(
-        color = it.color.compose,
-        topLeft = PagePoint.drawingOffset(it.data[0], it.data[1]),
-        size = PagePoint.size(it.data[2], it.data[3]),
-        style = Stroke(width = 2f),
-      )
+      CIRCLE -> drawCircle(drawScope, it)
+      LINE -> drawLine(drawScope, it)
+      RECTANGLE -> drawRectangle(drawScope, it, color)
+      FILLED_RECTANGLE -> drawFilledRectangle(drawScope, it, color)
+      USE -> drawUse(drawScope, it)
     }
   }
 }
+
+private fun highlightIfCurrentPipe(drawingOrder: DrawingOrder) =
+  if (drawingOrder.entity is Pipe
+    && PipeManager.list[PipeManager.current].pipe == drawingOrder.entity
+  ) {
+    Color.Magenta
+  } else {
+    drawingOrder.color.compose
+  }
+
+private fun drawCircle(
+  drawScope: DrawScope,
+  drawingOrder: DrawingOrder,
+) =
+  drawScope.drawCircle(
+    color = drawingOrder.color.compose,
+    center = PagePoint.drawingOffset(drawingOrder.data[0], drawingOrder.data[1]),
+    radius = drawingOrder.data[2] * PagePoint.Scale,
+    style = Stroke(width = 2f)
+  )
+
+private fun drawLine(drawScope: DrawScope, drawingOrder: DrawingOrder) =
+  drawScope.drawLine(
+    color = drawingOrder.color.compose,
+    start = PagePoint.drawingOffset(drawingOrder.data[0], drawingOrder.data[1]),
+    end = PagePoint.drawingOffset(drawingOrder.data[2], drawingOrder.data[3]),
+  )
+
+private fun drawRectangle(
+  drawScope: DrawScope,
+  drawingOrder: DrawingOrder,
+  color: Color,
+) =
+  drawScope.drawRect(
+    color = color,
+    topLeft = PagePoint.drawingOffset(drawingOrder.data[0], drawingOrder.data[1]),
+    size = PagePoint.size(drawingOrder.data[2], drawingOrder.data[3]),
+    style = Stroke(width = 2f),
+  )
+
+private fun drawFilledRectangle(
+  drawScope: DrawScope,
+  drawingOrder: DrawingOrder,
+  color: Color,
+) =
+  drawScope.drawRect(
+    color = color.copy(alpha = drawingOrder.opacity),
+    topLeft = PagePoint.drawingOffset(drawingOrder.data[0], drawingOrder.data[1]),
+    size = PagePoint.size(drawingOrder.data[2], drawingOrder.data[3]),
+  )
+
+private fun drawUse(drawScope: DrawScope, drawingOrder: DrawingOrder) {
+  val type = drawingOrder.useType
+  val x = drawingOrder.data[0]
+  val y = drawingOrder.data[1]
+  val luminaireDefinition = LuminaireDefinition.findByName(type)
+  val size = (luminaireDefinition?.length?.coerceAtLeast(luminaireDefinition.width) ?: 0f) / 2
+  drawScope.drawLine(
+    color = Color.Black,
+    start = PagePoint.drawingOffset(x, y - size),
+    end = PagePoint.drawingOffset(x, y + size)
+  )
+}
+
+

--- a/src/main/kotlin/display/DrawEntitiesCompose.kt
+++ b/src/main/kotlin/display/DrawEntitiesCompose.kt
@@ -25,17 +25,11 @@ fun drawContent(drawScope: DrawScope) {
 
   }
 
+  Floor.instances.map { composeDraw(drawScope, it.drawPlan()) }
   Stair.instances.map { composeDraw(drawScope, it.drawPlan()) }
   composeDraw(drawScope, Proscenium.instances.first().drawPlan())
-
-  for (instance in PipeBase.instances) {
-    instance.draw(drawScope)
-  }
-
-  for (item in PipeManager.list) {
-    val instance = item.pipe
-    instance.draw(drawScope, item.current)
-  }
+  PipeBase.instances.map { composeDraw(drawScope, it.drawPlan()) }
+  PipeManager.list.map { composeDraw(drawScope,it.pipe.drawPlan()) }
 
   for (instance in Setpiece.instances) {
     instance.draw(drawScope)

--- a/src/main/kotlin/display/DrawEntitiesSvg.kt
+++ b/src/main/kotlin/display/DrawEntitiesSvg.kt
@@ -27,12 +27,13 @@ fun drawSvgPlanContent(svgDocument: SvgDocument) {
   var boundary = SvgBoundary()
 
   Wall.instances.map { boundary += it.drawSvgPlan(svgDocument) }
-  Floor.instances.map { it.drawSvgPlan(svgDocument) }
-  Stair.instances.map { svgDraw(svgDocument, it.drawPlan()) }
-  svgDraw(svgDocument, Proscenium.instances.first().drawPlan())
+  Floor.instances.map { svgDraw(svgDocument, it.drawPlan()) }
+  Stair.instances.map { boundary += svgDraw(svgDocument, it.drawPlan()) }
+  boundary += svgDraw(svgDocument, Proscenium.instances.first().drawPlan())
+  PipeBase.instances.map { svgDraw(svgDocument, it.drawPlan()) }
+//  Pipe.instances.map { boundary += it.drawSvgPlan(svgDocument) }
+  Pipe.instances.map { boundary += svgDraw(svgDocument, it.drawPlan()) }
   Setpiece.instances.map { it.drawSvgPlan(svgDocument) }
-  PipeBase.instances.map { it.drawSvgPlan(svgDocument) }
-  Pipe.instances.map { boundary += it.drawSvgPlan(svgDocument) }
 
   svgDocument.root.setAttribute("height", (boundary.yMax + 50).toString())
 }
@@ -42,14 +43,17 @@ fun drawSvgSectionContent(svgDocument: SvgDocument) {
 //      see https://stackoverflow.com/questions/2724415/how-to-resize-an-svg-with-batik-and-display-it
 
   generateSvgSymbols(svgDocument)
+  var boundary = SvgBoundary()
 
 //  val (document, svgNamespace, generator, parentElement) = svgDocument
 
   Venue.instances.first().drawSvgSection(svgDocument)
-  Floor.instances.map { it.drawSvgSection(svgDocument) }
-  svgDraw(svgDocument, Proscenium.instances.first().drawSection())
-  Stair.instances.map { svgDraw(svgDocument, it.drawSection()) }
 //  Wall.instances.map { it.drawSvgSection(svgDocument) }
+  Floor.instances.map { svgDraw(svgDocument, it.drawSection()) }
+  Stair.instances.map { boundary += svgDraw(svgDocument, it.drawSection()) }
+  boundary += svgDraw(svgDocument, Proscenium.instances.first().drawSection())
+  Pipe.instances.map { boundary += svgDraw(svgDocument, it.drawSection()) }
+  Setpiece.instances.map { svgDraw(svgDocument, it.drawSection()) }
 }
 
 fun LuminaireDefinition.drawSvgPlan(svgDocument: SvgDocument) =
@@ -61,23 +65,6 @@ fun Venue.drawSvgSection(svgDocument: SvgDocument) {
 
 fun Wall.drawSvgPlan(svgDocument: SvgDocument): SvgBoundary {
   return drawLine(svgDocument, start, end)
-}
-
-fun Floor.drawSvgPlan(svgDocument: SvgDocument) {
-  drawRectangle(svgDocument, surface.x, surface.y, surface.width, surface.depth, "grey", "0.1")
-}
-
-fun Floor.drawSvgSection(svgDocument: SvgDocument) {
-  val venue = Venue.instances.first()
-  val height = venue.height - surface.z
-  val originY = venue.depth - surface.y - surface.depth
-
-  drawLine(svgDocument.document, svgDocument.namespace, svgDocument.root,
-    originY,
-    height,
-    originY + surface.depth,
-    height
-  )
 }
 
 fun PipeBase.drawSvgPlan(svgDocument: SvgDocument) {
@@ -139,10 +126,3 @@ fun Shape.drawSvgPlan(svgDocument: SvgDocument, placement: VenuePoint) {
   val originOffset = Point(placement.x - rectangle.width / 2, placement.y - rectangle.depth / 2, 0f)
   drawRectangle(svgDocument, originOffset.x, originOffset.y, rectangle.width, rectangle.depth)
 }
-
-data class Position(
-  val x: Float,
-  val y: Float,
-  val width: Float,
-  val height: Float,
-)

--- a/src/main/kotlin/display/DrawingOrder.kt
+++ b/src/main/kotlin/display/DrawingOrder.kt
@@ -1,9 +1,13 @@
 package display
 
+import XmlElemental
 import androidx.compose.ui.graphics.Color
 
 data class DrawingOrder(
   val operation: DrawingOrderOperation,
+  val entity: XmlElemental,
   val data: List<Float>,
+  val useType: String = "",
   val color: IndependentColor = IndependentColor(Color.Black, "black"),
+  val opacity: Float = 0F
 )

--- a/src/main/kotlin/display/DrawingOrderOperation.kt
+++ b/src/main/kotlin/display/DrawingOrderOperation.kt
@@ -4,4 +4,6 @@ enum class DrawingOrderOperation {
   CIRCLE,  // Circle data is: x, y, r
   LINE,  // Line data is: x1, y1, x2, y2
   RECTANGLE, // Rectangle data is: x, y, width, height
+  FILLED_RECTANGLE, // Rectangle data is: x, y, width, height
+  USE, // Use data is: x, y. useType must be provided.
 }

--- a/src/main/kotlin/display/EntitiesDraw.kt
+++ b/src/main/kotlin/display/EntitiesDraw.kt
@@ -1,7 +1,22 @@
 package display
 
+import display.DrawingOrderOperation.CIRCLE
+import display.DrawingOrderOperation.LINE
+import display.DrawingOrderOperation.RECTANGLE
+import display.DrawingOrderOperation.FILLED_RECTANGLE
+import display.DrawingOrderOperation.USE
 import androidx.compose.ui.graphics.Color
+import coordinates.Point
+import coordinates.StagePoint
+import coordinates.VenuePoint
+import entities.Floor
+import entities.Luminaire
+import entities.Pipe
+import entities.PipeBase
 import entities.Proscenium
+import entities.SetPlatform
+import entities.Setpiece
+import entities.Shape
 import entities.Stair
 import entities.Venue
 import java.lang.Float.min
@@ -11,48 +26,54 @@ fun Proscenium.drawPlan(): List<DrawingOrder> {
   val startX = origin.x - width / 2
   val startY = origin.y
   val endX = origin.x + width / 2
-  val endY = origin.y + depth
+  val endY = origin.y - depth
   val originSize = 7f
 
   val drawingOrders: MutableList<DrawingOrder> = mutableListOf()
 
   val cyan = IndependentColor(Color.Cyan, "cyan")
   drawingOrders.add(DrawingOrder(
-    DrawingOrderOperation.LINE,
-    listOf(origin.x - originSize, endY - originSize, origin.x + originSize, endY + originSize),
-    cyan
+    operation = LINE,
+    entity = this,
+    data = listOf(origin.x - originSize, origin.y - originSize, origin.x + originSize, origin.y + originSize),
+    color = cyan
   ))
   drawingOrders.add(DrawingOrder(
-    DrawingOrderOperation.LINE,
-    listOf(origin.x + originSize, endY - originSize, origin.x - originSize, endY + originSize),
-    cyan
+    operation = LINE,
+    entity = this,
+    data = listOf(origin.x + originSize, origin.y - originSize, origin.x - originSize, origin.y + originSize),
+    color = cyan
   ))
 //  drawingOrders.add(DrawingOrder(
-//    DrawingOrderOperation.CIRCLE,
-//    listOf(origin.x, endY, originSize),
+//    CIRCLE,
+//    data = listOf(origin.x, endY, originSize),
 //    cyan
 //  ))
   // SR end of proscenium arch
   drawingOrders.add(DrawingOrder(
-    DrawingOrderOperation.LINE,
-    listOf(startX, startY, startX, endY),
+    operation = LINE,
+    entity = this,
+    data = listOf(startX, startY, startX, endY),
   ))
   // SL end of proscenium arch
   drawingOrders.add(DrawingOrder(
-    DrawingOrderOperation.LINE,
-    listOf(endX, startY, endX, endY),
+    operation = LINE,
+    entity = this,
+    data = listOf(endX, startY, endX, endY),
   ))
   // US side of proscenium arch
   drawingOrders.add(DrawingOrder(
-    DrawingOrderOperation.LINE,
-    listOf(startX, startY, endX, startY),
-    IndependentColor(Color.Gray, "grey")
+    operation = LINE,
+    entity = this,
+    data = listOf(startX, endY, endX, endY),
+    color = IndependentColor(Color.Gray, "grey")
   ))
   // DS side of proscenium arch
   drawingOrders.add(DrawingOrder(
-    DrawingOrderOperation.LINE,
-    listOf(startX, endY, endX, endY),
-    IndependentColor(Color.LightGray, "lightgrey")
+    operation = LINE,
+    entity = this,
+    data = listOf(startX, startY, endX, startY),
+    color = IndependentColor(Color.LightGray, "lightgrey")
   ))
 
   return drawingOrders.toList()
@@ -68,33 +89,81 @@ fun Proscenium.drawSection(): List<DrawingOrder> {
 
   val cyan = IndependentColor(Color.Cyan, "cyan")
   drawingOrders.add(DrawingOrder(
-    DrawingOrderOperation.LINE,
-    listOf(originY - originSize, floorHeight - originSize, originY + originSize, floorHeight + originSize),
-    cyan
+    operation = LINE,
+    entity = this,
+    data = listOf(originY - originSize, floorHeight - originSize, originY + originSize, floorHeight + originSize),
+    color = cyan
   ))
   drawingOrders.add(DrawingOrder(
-    DrawingOrderOperation.LINE,
-    listOf(originY + originSize, floorHeight - originSize, originY - originSize, floorHeight + originSize),
-    cyan
+    operation = LINE,
+    entity = this,
+    data = listOf(originY + originSize, floorHeight - originSize, originY - originSize, floorHeight + originSize),
+    color = cyan
   ))
 //  drawingOrders.add(DrawingOrder(
-//    DrawingOrderOperation.CIRCLE,
-//    listOf(originY, floorHeight, originSize),
+//    CIRCLE,
+//    data = listOf(originY, floorHeight, originSize),
 //    cyan
 //  ))
   drawingOrders.add(DrawingOrder(
-    DrawingOrderOperation.LINE,
-    listOf(originY, floorHeight, originY, floorHeight - height),
-    IndependentColor(Color.Green, "green")
+    operation = LINE,
+    entity = this,
+    data = listOf(originY, floorHeight, originY, floorHeight - height),
+    color = IndependentColor(Color.Green, "green")
   ))
   drawingOrders.add(DrawingOrder(
-    DrawingOrderOperation.LINE,
-    listOf(originY + depth, floorHeight, originY + depth, floorHeight - height),
+    operation = LINE,
+    entity = this,
+    data = listOf(originY + depth, floorHeight, originY + depth, floorHeight - height),
   ))
   drawingOrders.add(DrawingOrder(
-    DrawingOrderOperation.LINE,
-    listOf(originY, floorHeight - height, originY + depth, floorHeight - height),
-    IndependentColor(Color.Gray, "grey")
+    operation = LINE,
+    entity = this,
+    data = listOf(originY, floorHeight - height, originY + depth, floorHeight - height),
+    color = IndependentColor(Color.Gray, "grey")
+  ))
+
+  return drawingOrders.toList()
+}
+
+fun Floor.drawPlan(): List<DrawingOrder> {
+
+  val drawingOrders: MutableList<DrawingOrder> = mutableListOf()
+
+  drawingOrders.add(DrawingOrder(
+    operation = FILLED_RECTANGLE,
+    entity = this,
+    data = listOf(surface.x, surface.y, surface.width, surface.depth),
+    color = IndependentColor(Color.Gray, "grey"),
+    opacity = 0.1F,
+  ))
+
+  return drawingOrders.toList()
+}
+
+fun Floor.drawSection(): List<DrawingOrder> {
+  val venue = Venue.instances.first()
+  val height = venue.height - surface.z
+  val originY = venue.depth - surface.y - surface.depth
+
+  val drawingOrders: MutableList<DrawingOrder> = mutableListOf()
+
+  drawingOrders.add(DrawingOrder(
+    operation = LINE,
+    entity = this,
+    data = listOf(originY, height, originY + surface.depth, height)
+  ))
+  drawingOrders.add(DrawingOrder(
+    operation = LINE,
+    entity = this,
+    data = listOf(originY, height, originY, venue.height.toFloat())
+  ))
+  drawingOrders.add(DrawingOrder(
+    FILLED_RECTANGLE,
+    entity = this,
+    data = listOf(originY, height, surface.depth, surface.z),
+    color = IndependentColor(Color.Gray, "grey"),
+    opacity = 0.1F,
   ))
 
   return drawingOrders.toList()
@@ -106,8 +175,9 @@ fun Stair.drawPlan(): List<DrawingOrder> {
 
   repeat(steps) { index ->
     drawingOrders.add(DrawingOrder(
-      DrawingOrderOperation.RECTANGLE,
-      listOf(origin.x, origin.y + index * run, width, run),
+      RECTANGLE,
+      entity = this,
+      data = listOf(origin.x, origin.y + index * run, width, run),
     ))
   }
 
@@ -121,8 +191,9 @@ fun Stair.drawSection(): List<DrawingOrder> {
 
   repeat(steps) { index ->
     drawingOrders.add(DrawingOrder(
-      DrawingOrderOperation.LINE,
-      listOf(
+      operation = LINE,
+      entity = this,
+      data = listOf(
         venue.depth - origin.y - run * (index + 1),
         venue.height - origin.z + rise * index,
         venue.depth - origin.y - run * index,
@@ -130,15 +201,182 @@ fun Stair.drawSection(): List<DrawingOrder> {
       )
     ))
     drawingOrders.add(DrawingOrder(
-      DrawingOrderOperation.LINE,
-      listOf(
+      operation = LINE,
+      entity = this,
+      data = listOf(
         venue.depth - origin.y - run * (index + 1),
         venue.height - origin.z + rise * index,
         venue.depth - origin.y - run * (index + 1),
-        min( venue.height.toFloat(), venue.height - origin.z + rise *  (index + 1))
+        min(venue.height.toFloat(), venue.height - origin.z + rise * (index + 1))
       )
     ))
   }
+
+  return drawingOrders.toList()
+}
+
+fun PipeBase.drawPlan(): List<DrawingOrder> {
+  val drawingOrders: MutableList<DrawingOrder> = mutableListOf()
+  val place = origin.venue
+
+  drawingOrders.add(DrawingOrder(
+    operation = CIRCLE,
+    entity = this,
+    data = listOf(place.x, place.y, PipeBase.Radius)
+  ))
+
+  return drawingOrders.toList()
+}
+
+fun Pipe.drawPlan(): List<DrawingOrder> {
+  return when (vertical) {
+    true -> drawPlanVertical()
+    else -> drawPlanHorizontal()
+  }
+}
+
+fun Pipe.drawPlanVertical(): List<DrawingOrder> {
+  val drawingOrders: MutableList<DrawingOrder> = mutableListOf()
+  val place = origin.venue
+
+  drawingOrders.add(DrawingOrder(
+    operation = CIRCLE,
+    entity = this,
+    data = listOf(place.x, place.y, Pipe.Diameter / 2)
+  ))
+
+  return drawingOrders.toList()
+}
+
+fun Pipe.drawPlanHorizontal(): List<DrawingOrder> {
+  val drawingOrders: MutableList<DrawingOrder> = mutableListOf()
+  val place = origin.venue
+
+  drawingOrders.add(DrawingOrder(
+    operation = RECTANGLE,
+    entity = this,
+    data = listOf(place.x, place.y, length, Pipe.Diameter)
+  ))
+  val offsetToCenter = length / 2
+  dependents.forEach {
+    val location = place.x + it.location + offsetToCenter
+    val luminaire = it.hangable as Luminaire
+    drawingOrders.add(DrawingOrder(
+      operation = USE,
+      entity = luminaire,
+      data = listOf(location, place.y),
+      useType = luminaire.type,
+    ))
+  }
+  return drawingOrders.toList()
+}
+
+fun Pipe.drawSection(): List<DrawingOrder> {
+  return when (vertical) {
+    true -> drawSectionVertical()
+    else -> drawSectionHorizontal()
+  }
+}
+
+fun Pipe.drawSectionVertical(): List<DrawingOrder> {
+  val drawingOrders: MutableList<DrawingOrder> = mutableListOf()
+  val venue = Venue.instances.first()
+  val place = origin.venue
+
+  drawingOrders.add(DrawingOrder(
+    operation = RECTANGLE,
+    entity = this,
+    data = listOf(
+      venue.depth - place.y,
+      venue.height - place.z - length,
+      Pipe.Diameter,
+      length,
+    )
+  ))
+  dependents.forEach {
+    when (it.hangable) {
+      is Luminaire -> {
+        val luminaire = it.hangable as Luminaire
+        drawingOrders.add(DrawingOrder(
+          operation = USE,
+          entity = luminaire,
+          data = listOf(
+            venue.depth - place.y,
+            venue.height - place.z - it.location,
+          ),
+          useType = luminaire.type,
+        ))
+      }
+      is Pipe -> {}
+    }
+  }
+
+  return drawingOrders.toList()
+}
+
+fun Pipe.drawSectionHorizontal(): List<DrawingOrder> {
+  val drawingOrders: MutableList<DrawingOrder> = mutableListOf()
+  val venue = Venue.instances.first()
+  val place = origin.venue
+
+  drawingOrders.add(DrawingOrder(
+    operation = CIRCLE,
+    entity = this,
+    data = listOf(
+      venue.depth - place.y,
+      venue.height - place.z,
+      Pipe.Diameter / 2
+    )
+  ))
+  dependents.forEach {
+    val luminaire = it.hangable as Luminaire
+    drawingOrders.add(DrawingOrder(
+      operation = USE,
+      entity = luminaire,
+      data = listOf(
+        venue.depth - place.y,
+        venue.height - place.z,
+      ),
+      useType = luminaire.type,
+    ))
+  }
+
+  return drawingOrders.toList()
+}
+
+fun Setpiece.drawSection(): List<DrawingOrder> {
+  return parts.flatMap { it.drawSection(origin.venue) }
+}
+
+fun SetPlatform.drawSection(placement: VenuePoint): List<DrawingOrder> {
+  val platformPlacement = placement + origin
+  return shapes.flatMap { it.drawSection(placement, platformPlacement) }
+}
+
+fun Shape.drawSection(placement: VenuePoint, platformPlacement: VenuePoint): List<DrawingOrder> {
+  val venue = Venue.instances.first()
+  val height = venue.height - platformPlacement.z
+  val frontY = venue.depth - platformPlacement.y - rectangle.depth / 2
+  val rearY = venue.depth - platformPlacement.y + rectangle.depth / 2
+  val floor = venue.height - placement.z
+
+  val drawingOrders: MutableList<DrawingOrder> = mutableListOf()
+
+  drawingOrders.add(DrawingOrder(
+    operation = LINE,
+    entity = this,
+    data = listOf(frontY, height, frontY + rectangle.depth, height)
+  ))
+  drawingOrders.add(DrawingOrder(
+    operation = LINE,
+    entity = this,
+    data = listOf(frontY, height, frontY, floor)
+  ))
+  drawingOrders.add(DrawingOrder(
+    operation = LINE,
+    entity = this,
+    data = listOf(rearY, height, rearY, floor)
+  ))
 
   return drawingOrders.toList()
 }

--- a/src/main/kotlin/entities/Proscenium.kt
+++ b/src/main/kotlin/entities/Proscenium.kt
@@ -21,7 +21,7 @@ class Proscenium(elementPassthrough: Element, parentEntity: XmlElemental?) : Xml
   companion object : CreateWithXmlElement<Proscenium>() {
     const val Tag = "proscenium"
 
-    fun factory(xmlElement: Element, parentEntity: XmlElemental?): Proscenium =
+    fun factory(xmlElement: Element, parentEntity: XmlElemental? = null): Proscenium =
       create(xmlElement, parentEntity, ::Proscenium)
 
     fun inUse(): Boolean {

--- a/src/main/kotlin/entities/Venue.kt
+++ b/src/main/kotlin/entities/Venue.kt
@@ -4,7 +4,7 @@ import CreateWithXmlElement
 import XmlElemental
 import org.w3c.dom.Element
 
-class Venue(elementPassthrough: Element, parentEntity: XmlElemental? ) : XmlElemental(elementPassthrough) {
+class Venue(elementPassthrough: Element, parentEntity: XmlElemental?) : XmlElemental(elementPassthrough) {
   var building = getStringAttribute("building")
   var room = getStringAttribute("room")
   var width = getPositiveIntegerAttribute("width")
@@ -21,8 +21,8 @@ class Venue(elementPassthrough: Element, parentEntity: XmlElemental? ) : XmlElem
   companion object : CreateWithXmlElement<Venue>() {
     const val Tag = "venue"
 
-    fun factory(xmlElement: Element, parentEntity: XmlElemental?): Venue =
-      create(xmlElement,parentEntity, ::Venue)
+    fun factory(xmlElement: Element, parentEntity: XmlElemental? = null): Venue =
+      create(xmlElement, parentEntity, ::Venue)
   }
 }
 

--- a/src/main/kotlin/sidebar/PipeSideBar.kt
+++ b/src/main/kotlin/sidebar/PipeSideBar.kt
@@ -25,7 +25,8 @@ class PipeSideBar {
   companion object {
     @OptIn(ExperimentalFoundationApi::class)
     @Composable
-    fun pipeLister(pipes: List<PipeManager>, selectPipe: (PipeManager) -> Unit) {
+    fun pipeLister(pipes: List<PipeManager>) {
+//    fun pipeLister(pipes: List<PipeManager>, selectPipe: (PipeManager) -> Unit) {
 
       Column(
         modifier = Modifier
@@ -40,7 +41,8 @@ class PipeSideBar {
             modifier = Modifier
               .fillMaxWidth(1f)
               .combinedClickable(
-                onClick = { selectPipe(pipeOrdering) },
+                onClick = { PipeManager.makeCurrent(pipeOrdering) },
+//                onClick = { selectPipe(pipeOrdering) },
               ),
 
             ) {

--- a/src/test/kotlin/tests/DrawEntitiesSvgTest.kt
+++ b/src/test/kotlin/tests/DrawEntitiesSvgTest.kt
@@ -2,6 +2,7 @@ package tests
 
 import coordinates.VenuePoint
 import display.SvgBoundary
+import display.drawPlan
 import display.drawSvgPlan
 //import display.drawSvgPlan
 import entities.Floor
@@ -38,22 +39,6 @@ class DrawEntitiesSvgTest {
     xmlElement.setAttribute("type", "name")
     xmlElement.setAttribute("location", "1.6")
     return xmlElement
-  }
-
-  @Test
-  fun `Floor drawSvgPlan shows semi-opaque rectangle`() {
-    val floor = Floor.factory(FloorTest().minimalXml())
-    val svgDocument = startSvg()
-    val initialNodeCount = svgDocument.root.childNodes.length
-    assertThat(svgDocument.root.getElementsByTagName("rect").length).isEqualTo(0)
-
-    floor.drawSvgPlan(svgDocument)
-
-    assertThat(svgDocument.root.childNodes.length).isEqualTo(initialNodeCount + 1)
-    val circleElements = svgDocument.root.getElementsByTagName("rect")
-    assertThat(circleElements.length).isEqualTo(1)
-    val opacityAttribute = circleElements.item(0).attributes.getNamedItem("opacity")
-    assertThat(opacityAttribute.textContent.toFloat()).isEqualTo(0.1f)
   }
 
   @Test

--- a/src/test/kotlin/tests/SvgDrawingToolsTest.kt
+++ b/src/test/kotlin/tests/SvgDrawingToolsTest.kt
@@ -28,7 +28,7 @@ class SvgDrawingToolsTest {
       assertThat(attributes.getNamedItem("cy").textContent.toFloat()).isEqualTo(2f)
       assertThat(attributes.getNamedItem("r").textContent.toFloat()).isEqualTo(3f)
       assertThat(attributes.getNamedItem("stroke").textContent).isEqualTo("black")
-      assertThat(attributes.getNamedItem("stroke-width").textContent).isEqualTo("2")
+      assertThat(attributes.getNamedItem("stroke-width").textContent).isEqualTo("1")
       assertThat(attributes.getNamedItem("fill").textContent).isEqualTo("none")
     }.assertAll()
   }

--- a/src/test/kotlin/tests/display/EntitiesDrawTest.kt
+++ b/src/test/kotlin/tests/display/EntitiesDrawTest.kt
@@ -1,0 +1,71 @@
+package tests.display
+
+import androidx.compose.ui.graphics.Color
+import display.DrawingOrderOperation
+import display.IndependentColor
+import display.drawPlan
+import display.drawSection
+import entities.Floor
+import entities.Proscenium
+import entities.Venue
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.tuple
+import org.assertj.core.api.SoftAssertions
+import kotlin.test.Test
+import tests.entities.FloorTest
+import tests.entities.ProsceniumTest
+import tests.entities.VenueTest
+
+class EntitiesDrawTest {
+
+  @Test
+  fun `Proscenium drawPlan orders`() {
+    val proscenium = Proscenium.factory(ProsceniumTest().minimalXml())
+
+    val orders = proscenium.drawPlan()
+
+    assertThat(orders).hasSize(6)
+    assertThat(orders).extracting("operation", "entity")
+      .containsOnly(
+        tuple(DrawingOrderOperation.LINE, proscenium),
+      )
+    // Colors not tested
+  }
+
+  @Test
+  fun `Floor drawPlan orders filled rectangle`() {
+    val floor = Floor.factory(FloorTest().minimalXml())
+
+    val orders = floor.drawPlan()
+
+    assertThat(orders).hasSize(1)
+    val order = orders.first()
+    SoftAssertions().apply {
+      assertThat(order.operation).isEqualTo(DrawingOrderOperation.FILLED_RECTANGLE)
+      assertThat(order.entity).isInstanceOf(Floor::class.java)
+      assertThat(order.color).isEqualTo(IndependentColor(Color.Gray, "grey"))
+      assertThat(order.opacity).isEqualTo(0.1F)
+    }.assertAll()
+  }
+
+  @Test
+  fun `Floor drawSection orders`() {
+    Venue.factory(VenueTest().minimalXml())
+    val floor = Floor.factory(FloorTest().minimalXml())
+
+    val orders = floor.drawSection()
+
+    assertThat(orders).hasSize(3)
+    assertThat(orders).extracting("operation", "entity")
+      .containsExactlyInAnyOrder(
+        tuple(DrawingOrderOperation.LINE, floor),
+        tuple(DrawingOrderOperation.LINE, floor),
+        tuple(DrawingOrderOperation.FILLED_RECTANGLE, floor)
+      )
+    assertThat(orders).extracting("operation", "entity", "color", "opacity")
+      .contains(
+        tuple(DrawingOrderOperation.FILLED_RECTANGLE, floor, IndependentColor(Color.Gray, "grey"), 0.1f)
+
+      )
+  }
+}


### PR DESCRIPTION
We are now able to order filled rectangles (in addition to the outlined ones) and use SVG symbols on the SVG side. Still need to figure out how to draw luminaire icons in Compose.